### PR TITLE
Change to matrix indexing section

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -280,7 +280,7 @@
    "source": [
     "We can also use indexing to address and assign new values to elements of a matrix as shown below:\n",
     "```python\n",
-    "X[:, 0] = [[11], [12], [13]] # set column 0\n",
+    "X[:, 0] = [11, 12, 13] # set column 0\n",
     "X[2, 2] = 15           # set a single element in third row and third column\n",
     "print (X)\n",
     "\n",


### PR DESCRIPTION
This currently throws a value error: setting an array element with a sequence. The proposed change correctly reassigns the values in the first column.